### PR TITLE
adding errors header

### DIFF
--- a/include/opencv_candidate/feature2d.hpp
+++ b/include/opencv_candidate/feature2d.hpp
@@ -37,6 +37,7 @@
 #define FEATURE2D_HPP_
 
 #include <opencv2/core/core.hpp>
+#include <opencv2/core/types_c.h>
 #include <opencv2/features2d/features2d.hpp>
 
 namespace feature2d


### PR DESCRIPTION
solving that:

CV_Error(CV_StsNotImplemented, "Not implemented method because it's not efficient to split feature detection and description extraction here\n");
